### PR TITLE
DOC: Update qsub preinstall command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * Connect to the cluster `ssh login1.int.janelia.org`.
 * Run `qlogin`.
 * Run our configuration file `curl https://raw.githubusercontent.com/nanshe-org/nanshe_workflow_deploy_janelia/master/1_preinstall_nanshe_workflow.sh | bash`.
-* Alternatively, this can be run in the background `echo 'https://raw.githubusercontent.com/nanshe-org/nanshe_workflow_deploy_janelia/master/1_preinstall_nanshe_workflow.sh | bash' | qsub`. Check to make sure it is done by running `qstat` and verifying `STDIN` is no longer in the job list returned.
+* Alternatively, this can be run in the background `echo 'curl https://raw.githubusercontent.com/nanshe-org/nanshe_workflow_deploy_janelia/master/1_preinstall_nanshe_workflow.sh | bash' | qsub`. Check to make sure it is done by running `qstat` and verifying `STDIN` is no longer in the job list returned.
 * Logout of the cluster. All changes will take effect on the next login.
 
 # Installing/Updating


### PR DESCRIPTION
Was missing `curl` to download the script. This adds it so that the `qsub` command will work.