### PR TITLE
BUG: Download Miniconda via HTTPS

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -32,7 +32,7 @@
 
 # Download and install conda.
 rm -rf ~/miniconda
-curl http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > ~/miniconda.sh
+curl -L https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
 rm -f ~/miniconda.sh
 


### PR DESCRIPTION
Download Miniconda via HTTPS as it is no longer permissible to download via HTTP.