### PR TITLE
Fix conda-build pinning

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -42,7 +42,7 @@ source ~/miniconda/bin/activate root
 # Pin packages that need pinning.
 rm -f ~/miniconda/conda-meta/pinned
 touch ~/miniconda/conda-meta/pinned
-echo "conda-build ==1.16.0" >> ~/miniconda/conda-meta/pinned
+echo "conda-build 1.*" >> ~/miniconda/conda-meta/pinned
 
 # Add channels.
 conda config --add channels conda-forge

--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -40,8 +40,9 @@ rm -f ~/miniconda.sh
 source ~/miniconda/bin/activate root
 
 # Pin packages that need pinning.
+rm -f ~/miniconda/conda-meta/pinned
 touch ~/miniconda/conda-meta/pinned
-echo "conda-build ==1.16.0" > ~/miniconda/conda-meta/pinned
+echo "conda-build ==1.16.0" >> ~/miniconda/conda-meta/pinned
 
 # Add channels.
 conda config --add channels conda-forge


### PR DESCRIPTION
Changes the `conda-build` pinning to `1.*` instead of `1.16.0` as we rely on newer features to build the workflow.