### PR TITLE
Unset XDG_RUNTIME_DIR

### DIFF
--- a/3_startup_nanshe_workflow.sh
+++ b/3_startup_nanshe_workflow.sh
@@ -30,6 +30,13 @@
 # OF SUCH DAMAGE.
 
 
+# Unset XDG_RUNTIME_DIR as we lose write permission to this directory in `qsub`
+# and Jupyter wants to be able to write some files there if it is set.
+#
+# xref: https://github.com/jupyter/notebook/issues/1923
+#
+unset XDG_RUNTIME_DIR
+
 # Remove the config variables file at the beginning and the end.
 rm -f ~/ipython_notebook_config_vars
 trap "rm -f ~/ipython_notebook_config_vars" EXIT


### PR DESCRIPTION
Unset XDG_RUNTIME_DIR so Jupyter can write session files ok on the cluster. It appears we lose write access to this directory in a `qsub` jobs. 😕 In any event, this seems to be a viable workaround.

xref: https://github.com/jupyter/notebook/issues/1923