### PR TITLE
Support Jupyter tokens

### DIFF
--- a/4_connect_nanshe_workflow.sh
+++ b/4_connect_nanshe_workflow.sh
@@ -39,4 +39,4 @@ fi
 
 # Set variables to facilitate the connection.
 export `ssh login1.int.janelia.org 'cat ~/ipython_notebook_config_vars'`
-ssh -o ExitOnForwardFailure=yes -vnNTL $LOCAL_IPYTHON_PORT:localhost:$LOGIN_NODE_PORT login1.int.janelia.org 
+ssh -o ExitOnForwardFailure=yes -vnNTL $LOCAL_IPYTHON_PORT:localhost:$LOGIN_NODE_PORT login1.int.janelia.org

--- a/4_connect_nanshe_workflow.sh
+++ b/4_connect_nanshe_workflow.sh
@@ -38,5 +38,10 @@ then
 fi
 
 # Set variables to facilitate the connection.
-export `ssh login1.int.janelia.org 'cat ~/ipython_notebook_config_vars'`
+IPYTHON_CONFIG="`ssh login1.int.janelia.org 'cat ~/ipython_notebook_config_vars'`"
+set -x
+eval "${IPYTHON_CONFIG}"
+set +x
+unset IPYTHON_CONFIG
 ssh -o ExitOnForwardFailure=yes -vnNTL $LOCAL_IPYTHON_PORT:localhost:$LOGIN_NODE_PORT login1.int.janelia.org
+unset LOCAL_IPYTHON_PORT


### PR DESCRIPTION
Jupyter Notebook 4.3.0 introduced the use of session tokens as a basic default level of authentication. In order to access the Notebook, a user must now provide this token. The changes provided here exist to extract this token from the Notebooks `stderr` if it is available. This will be displayed to the user when connect to the login node so that they can copy paste it into the browser.