### PR TITLE
Drop unsetting of LOCAL_IPYTHON_PORT

### DIFF
--- a/4_connect_nanshe_workflow.sh
+++ b/4_connect_nanshe_workflow.sh
@@ -44,4 +44,3 @@ eval "${IPYTHON_CONFIG}"
 set +x
 unset IPYTHON_CONFIG
 ssh -o ExitOnForwardFailure=yes -vnNTL $LOCAL_IPYTHON_PORT:localhost:$LOGIN_NODE_PORT login1.int.janelia.org
-unset LOCAL_IPYTHON_PORT


### PR DESCRIPTION
This crept in with PR ( https://github.com/nanshe-org/nanshe_workflow_deploy_janelia/pull/8 ), but wasn't really needed as it wasn't exported. So we drop this unsetting as it happens already by the script ending.