### PR TITLE
Trust the notebook after installing

### DIFF
--- a/2_update_nanshe_workflow.sh
+++ b/2_update_nanshe_workflow.sh
@@ -57,3 +57,6 @@ git pull --ff
 # Build and install the workflow meta package.
 conda build nanshe_workflow.recipe
 conda install -y --use-local -n nanshenv nanshe_workflow
+
+# Trust the notebook.
+jupyter trust ~/nanshe_workflow/nanshe_ipython.ipynb


### PR DESCRIPTION
The notebook when cloned from git is not trusted by default. As a result, this presents a warning in the notebook menu bar. Given we know this notebook is ok and we don't want this warning to show up, simply telling Jupyter to trust the notebook should fix this.