### PR TITLE
Use Python 3 instead of Python 2

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -32,7 +32,7 @@
 
 # Download and install conda.
 rm -rf ~/miniconda
-curl -L https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh > ~/miniconda.sh
+curl -L https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh > ~/miniconda.sh
 bash ~/miniconda.sh -b -p ~/miniconda
 rm -f ~/miniconda.sh
 


### PR DESCRIPTION
This only configures the default environment. So users can still install a Python 2 environment if they wish. However some operations are just faster on Python 3. Also newer versions of software should be available that are simply not available on Python 2.