### PR TITLE
Install ipython and the Jupyter notebook directly

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -60,7 +60,7 @@ conda install -y -n nanshenv nanshe
 
 # Install some other dependencies that will be needed.
 conda install -y -n nanshenv drmaa splauncher
-conda install -y -n nanshenv ipython-notebook
+conda install -y -n nanshenv ipython notebook
 
 # Clean after all installs.
 conda clean -yitps


### PR DESCRIPTION
The ipython-notebook package is all but dead at this point. Plus it is just easier to install the `notebook` and `ipython` to get what we want on a regular basis. So that is what we do now.