### PR TITLE
Enable ExecuteTime

### DIFF
--- a/2_update_nanshe_workflow.sh
+++ b/2_update_nanshe_workflow.sh
@@ -60,3 +60,6 @@ conda install -y --use-local -n nanshenv nanshe_workflow
 
 # Trust the notebook.
 jupyter trust ~/nanshe_workflow/nanshe_ipython.ipynb
+
+# Enable ExecuteTime
+jupyter nbextension enable execute_time/ExecuteTime


### PR DESCRIPTION
Make sure that ExecuteTime is enabled so that we can see timestamps for all steps run in notebooks as well as how long they ran.