### PR TITLE
Clear execution times when clearing output

### DIFF
--- a/2_update_nanshe_workflow.sh
+++ b/2_update_nanshe_workflow.sh
@@ -63,3 +63,4 @@ jupyter trust ~/nanshe_workflow/nanshe_ipython.ipynb
 
 # Enable ExecuteTime
 jupyter nbextension enable execute_time/ExecuteTime
+python -c "from notebook.services.config import ConfigManager as C; C().update('notebook', {'ExecuteTime': {'clear_timings_on_clear_output': True}})"


### PR DESCRIPTION
Makes sure that the execution times are also cleared when clearing the notebook's output (e.g. "Kernel" > "Restart & Clear Output").