### PR TITLE
Use our own lsf-drmaa

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -59,7 +59,7 @@ conda create -y -n nanshenv python
 conda install -y -n nanshenv nanshe
 
 # Install some other dependencies that will be needed.
-conda install -y -n nanshenv drmaa splauncher
+conda install -y -n nanshenv lsf-drmaa drmaa splauncher
 conda install -y -n nanshenv ipython notebook
 
 # Clean after all installs.
@@ -106,7 +106,7 @@ echo "if [[ -f /misc/lsf/conf/profile.lsf ]]; then" >> ~/.nanshe_workflow.sh
 echo "    source /misc/lsf/conf/profile.lsf" >> ~/.nanshe_workflow.sh
 echo "    export LSB_STDOUT_DIRECT='Y'" >> ~/.nanshe_workflow.sh
 echo "    export LSB_JOB_REPORT_MAIL='N'" >> ~/.nanshe_workflow.sh
-echo "    export LSF_DRMAA_LIBRARY_PATH=/misc/sc/lsf/lib/libdrmaa.so.0.1.1" >> ~/.nanshe_workflow.sh
+echo "    export LSF_DRMAA_LIBRARY_PATH=\$HOME/miniconda/envs/nanshenv/lib/libdrmaa.so.0.1.1" >> ~/.nanshe_workflow.sh
 echo "    export DRMAA_LIBRARY_PATH=\$LSF_DRMAA_LIBRARY_PATH" >> ~/.nanshe_workflow.sh
 echo "fi" >> ~/.nanshe_workflow.sh
 echo "" >> ~/.nanshe_workflow.sh


### PR DESCRIPTION
As we need a copy of `lsf-drmaa`, which is compatible with our glibc requirements, we built our own copy and added it to the `nanshe` channel. Originally we built this for CentOS 6 (glibc 2.12) compatibility. However as the cluster has CentOS 5 (glibc 2.3), we decided to build `lsf-drmaa` on this older target instead for increased flexibility. Hence we change our install scripts for the workflow to install our `conda` package of `lsf-drmaa` and make sure that is the one we use with the Python `drmaa` library. This way we can use `lsf-drmaa` inside our CentOS 6 container even though the cluster is now running on CentOS 7 (glibc 2.17).