### PR TITLE
Set JUPYTER_RUNTIME_DIR explicitly

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -117,6 +117,12 @@ echo "# we don't find parallelism from the BLAS to be too helpful." >> ~/.nanshe
 echo "# So we ensure that it isn't parallelized." >> ~/.nanshe_workflow.sh
 echo "export OPENBLAS_NUM_THREADS=1" >> ~/.nanshe_workflow.sh
 echo "" >> ~/.nanshe_workflow.sh
+echo "# Set the Jupyter runtime directory in the user's home." >> ~/.nanshe_workflow.sh
+echo "# This simply follows the recommendation of our cluster admins" >> ~/.nanshe_workflow.sh
+echo "# to redirect this to a different location than XDG_RUNTIME_DIR." >> ~/.nanshe_workflow.sh
+echo "# This is just what Jupyter picks when XDG_RUNTIME_DIR is disabled." >> ~/.nanshe_workflow.sh
+echo "export JUPYTER_RUNTIME_DIR=\$HOME/.local/share/jupyter/runtime" >> ~/.nanshe_workflow.sh
+echo "" >> ~/.nanshe_workflow.sh
 echo "# Add miniconda root to the path" >> ~/.nanshe_workflow.sh
 echo "PATH=\$HOME/miniconda/bin:\$PATH" >> ~/.nanshe_workflow.sh
 echo "" >> ~/.nanshe_workflow.sh


### PR DESCRIPTION
Based on advice from our cluster administrators, we should not allow Jupyter to write to the `XDG_RUNTIME_DIR`, which is what it will choose to do with Jupyter's runtime directory. To fix this, we tried seeing where Jupyter would pick to write to if `XDG_RUNTIME_DIR` were unset. In this case, Jupyter picked `~/.local/share/jupyter/runtime`. So we updated our scripts to simply set `JUPYTER_RUNTIME_DIR` to this same path. Should be easily accessible both under normal circumstances and within Singularity containers.