### PR TITLE
Use SciComp installed copy of our lsf-drmaa

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -59,7 +59,7 @@ conda create -y -n nanshenv python
 conda install -y -n nanshenv nanshe
 
 # Install some other dependencies that will be needed.
-conda install -y -n nanshenv lsf-drmaa drmaa splauncher
+conda install -y -n nanshenv drmaa splauncher
 conda install -y -n nanshenv ipython notebook
 
 # Clean after all installs.
@@ -106,7 +106,7 @@ echo "if [[ -f /misc/lsf/conf/profile.lsf ]]; then" >> ~/.nanshe_workflow.sh
 echo "    source /misc/lsf/conf/profile.lsf" >> ~/.nanshe_workflow.sh
 echo "    export LSB_STDOUT_DIRECT='Y'" >> ~/.nanshe_workflow.sh
 echo "    export LSB_JOB_REPORT_MAIL='N'" >> ~/.nanshe_workflow.sh
-echo "    export LSF_DRMAA_LIBRARY_PATH=\$HOME/miniconda/envs/nanshenv/lib/libdrmaa.so.0.1.1" >> ~/.nanshe_workflow.sh
+echo "    export LSF_DRMAA_LIBRARY_PATH=/misc/sc/lsf-glibc2.3/lib/libdrmaa.so.0.1.1" >> ~/.nanshe_workflow.sh
 echo "    export DRMAA_LIBRARY_PATH=\$LSF_DRMAA_LIBRARY_PATH" >> ~/.nanshe_workflow.sh
 echo "fi" >> ~/.nanshe_workflow.sh
 echo "" >> ~/.nanshe_workflow.sh


### PR DESCRIPTION
As SciComp has nicely agreed to install our copy of lsf-drmaa in a global directory we can access regardless of user, switch to using that instead of installing our own copy. This copy was built in a CentOS 5 container so supports glibc 2.3+, which is compatible with the glibc 2.3 install of LSF (oldest glibc supported by LSF on our cluster). Also will work great with our CentOS 6 based containers, which have glibc 2.12. Not to mention this continues to work fine under ScientificLinux 7, which uses glibc 2.17. Hence we drop our lsf-drmaa install and simply rely on this external copy. Will make it easier to simplify our requirements as we make more use of Singularity containers on the cluster.