### PR TITLE
Skip setting `OPENBLAS_NUM_THREADS`

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -65,13 +65,6 @@ echo '    export LSF_DRMAA_LIBRARY_PATH="/misc/sc/lsf-glibc2.3/lib/libdrmaa.so.0
 echo '    export DRMAA_LIBRARY_PATH="$LSF_DRMAA_LIBRARY_PATH"' >> ~/.nanshe_workflow.sh
 echo 'fi' >> ~/.nanshe_workflow.sh
 echo '' >> ~/.nanshe_workflow.sh
-echo '# Set the number of OpenBLAS threads to 1.' >> ~/.nanshe_workflow.sh
-echo '# As we parallelize blocks of data being processed' >> ~/.nanshe_workflow.sh
-echo '# and that gives us the most power when processing data,' >> ~/.nanshe_workflow.sh
-echo "# we don't find parallelism from the BLAS to be too helpful." >> ~/.nanshe_workflow.sh
-echo "# So we ensure that it isn't parallelized." >> ~/.nanshe_workflow.sh
-echo 'export OPENBLAS_NUM_THREADS=1' >> ~/.nanshe_workflow.sh
-echo '' >> ~/.nanshe_workflow.sh
 echo "# Set the Jupyter runtime directory in the user's home." >> ~/.nanshe_workflow.sh
 echo '# This simply follows the recommendation of our cluster admins' >> ~/.nanshe_workflow.sh
 echo '# to redirect this to a different location than XDG_RUNTIME_DIR.' >> ~/.nanshe_workflow.sh


### PR DESCRIPTION
As the container already sets `OPENBLAS_NUM_THREADS` to `1` internally, there is no need to specify this environment variable outside the context of the container. Hence this drops setting `OPENBLAS_NUM_THREADS`.