### PR TITLE
Use a block quote for `~/.nanshe_workflow.sh`

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -41,32 +41,34 @@ fi
 # (Re)Create our bash startup script to setup the environment.
 rm -f ~/.nanshe_workflow.sh
 touch ~/.nanshe_workflow.sh
-echo '# Set the temporary directory.' >> ~/.nanshe_workflow.sh
-echo 'TMPDIR="$HOME/tmp"' >> ~/.nanshe_workflow.sh
-echo 'TEMP="$TMPDIR"' >> ~/.nanshe_workflow.sh
-echo 'TMP="$TMPDIR"' >> ~/.nanshe_workflow.sh
-echo 'export TMPDIR TEMP TMP' >> ~/.nanshe_workflow.sh
-echo 'mkdir -p "$TMPDIR"' >> ~/.nanshe_workflow.sh
-echo '' >> ~/.nanshe_workflow.sh
-echo '# Export Grid Engine and DRMAA variables, if available.' >> ~/.nanshe_workflow.sh
-echo '# May not be available when using Linux locally or Windows with Git Bash.' >> ~/.nanshe_workflow.sh
-echo 'if [[ -f /sge/current/default/common/settings.sh ]]; then' >> ~/.nanshe_workflow.sh
-echo '    source /sge/current/default/common/settings.sh' >> ~/.nanshe_workflow.sh
-echo '    export SGE_DRMAA_LIBRARY_PATH="$SGE_ROOT/lib/lx-amd64/libdrmaa.so.1.0"' >> ~/.nanshe_workflow.sh
-echo '    export DRMAA_LIBRARY_PATH="$SGE_DRMAA_LIBRARY_PATH"' >> ~/.nanshe_workflow.sh
-echo 'fi' >> ~/.nanshe_workflow.sh
-echo '# Export LSF variables, if available.' >> ~/.nanshe_workflow.sh
-echo '# May not be available when using Linux locally or Windows with Git Bash.' >> ~/.nanshe_workflow.sh
-echo 'if [[ -f /misc/lsf/conf/profile.lsf ]]; then' >> ~/.nanshe_workflow.sh
-echo '    source /misc/lsf/conf/profile.lsf' >> ~/.nanshe_workflow.sh
-echo '    export LSB_STDOUT_DIRECT="Y"' >> ~/.nanshe_workflow.sh
-echo '    export LSB_JOB_REPORT_MAIL="N"' >> ~/.nanshe_workflow.sh
-echo '    export LSF_DRMAA_LIBRARY_PATH="/misc/sc/lsf-glibc2.3/lib/libdrmaa.so.0.1.1"' >> ~/.nanshe_workflow.sh
-echo '    export DRMAA_LIBRARY_PATH="$LSF_DRMAA_LIBRARY_PATH"' >> ~/.nanshe_workflow.sh
-echo 'fi' >> ~/.nanshe_workflow.sh
-echo '' >> ~/.nanshe_workflow.sh
-echo "# Set the Jupyter runtime directory in the user's home." >> ~/.nanshe_workflow.sh
-echo '# This simply follows the recommendation of our cluster admins' >> ~/.nanshe_workflow.sh
-echo '# to redirect this to a different location than XDG_RUNTIME_DIR.' >> ~/.nanshe_workflow.sh
-echo '# This is just what Jupyter picks when XDG_RUNTIME_DIR is disabled.' >> ~/.nanshe_workflow.sh
-echo 'export JUPYTER_RUNTIME_DIR="$HOME/.local/share/jupyter/runtime"' >> ~/.nanshe_workflow.sh
+cat > ~/.nanshe_workflow.sh << 'EOF'
+# Set the temporary directory.
+TMPDIR="$HOME/tmp"
+TEMP="$TMPDIR"
+TMP="$TMPDIR"
+export TMPDIR TEMP TMP
+mkdir -p "$TMPDIR"
+
+# Export Grid Engine and DRMAA variables, if available.
+# May not be available when using Linux locally or Windows with Git Bash.
+if [[ -f /sge/current/default/common/settings.sh ]]; then
+    source /sge/current/default/common/settings.sh
+    export SGE_DRMAA_LIBRARY_PATH="$SGE_ROOT/lib/lx-amd64/libdrmaa.so.1.0"
+    export DRMAA_LIBRARY_PATH="$SGE_DRMAA_LIBRARY_PATH"
+fi
+# Export LSF variables, if available.
+# May not be available when using Linux locally or Windows with Git Bash.
+if [[ -f /misc/lsf/conf/profile.lsf ]]; then
+    source /misc/lsf/conf/profile.lsf
+    export LSB_STDOUT_DIRECT="Y"
+    export LSB_JOB_REPORT_MAIL="N"
+    export LSF_DRMAA_LIBRARY_PATH="/misc/sc/lsf-glibc2.3/lib/libdrmaa.so.0.1.1"
+    export DRMAA_LIBRARY_PATH="$LSF_DRMAA_LIBRARY_PATH"
+fi
+
+# Set the Jupyter runtime directory in the user's home.
+# This simply follows the recommendation of our cluster admins
+# to redirect this to a different location than XDG_RUNTIME_DIR.
+# This is just what Jupyter picks when XDG_RUNTIME_DIR is disabled.
+export JUPYTER_RUNTIME_DIR="$HOME/.local/share/jupyter/runtime"
+EOF


### PR DESCRIPTION
Instead of having a bunch of `echo` lines to write out `~/.nanshe_workflow.sh`, use a block quote to write multiple lines at once. This makes it easier to read and edit. Also should avoid some pains with handling single/double quotes and environment variables in the text.