### PR TITLE
Skip setting `JUPYTER_RUNTIME_DIR`

### DIFF
--- a/1_preinstall_nanshe_workflow.sh
+++ b/1_preinstall_nanshe_workflow.sh
@@ -65,10 +65,4 @@ if [[ -f /misc/lsf/conf/profile.lsf ]]; then
     export LSF_DRMAA_LIBRARY_PATH="/misc/sc/lsf-glibc2.3/lib/libdrmaa.so.0.1.1"
     export DRMAA_LIBRARY_PATH="$LSF_DRMAA_LIBRARY_PATH"
 fi
-
-# Set the Jupyter runtime directory in the user's home.
-# This simply follows the recommendation of our cluster admins
-# to redirect this to a different location than XDG_RUNTIME_DIR.
-# This is just what Jupyter picks when XDG_RUNTIME_DIR is disabled.
-export JUPYTER_RUNTIME_DIR="$HOME/.local/share/jupyter/runtime"
 EOF


### PR DESCRIPTION
As the container now sets `JUPYTER_RUNTIME_DIR` to point to the default location in the user's directory, there is no need for us to set it in `~/.nanshe_workflow.sh` as well. So go ahead and drop setting of `JUPYTER_RUNTIME_DIR`.